### PR TITLE
Remove serverless version limitation + disable config validation

### DIFF
--- a/templates/nodejs/serverless.yml
+++ b/templates/nodejs/serverless.yml
@@ -1,6 +1,6 @@
 service: yandex-cloud-nodejs
 name: yandex-cloud-template
-frameworkVersion: ">=1.1.0 <2.0.0"
+configValidationMode: off
 
 provider:
   name: yandex-cloud


### PR DESCRIPTION
# Had following errors in deployment process:

```
The Serverless version (2.67.0) does not satisfy the "frameworkVersion" (>=1.1.0 <2.0.0) in serverless.yml
```

```
Warning: You're relying on provider "yandex-cloud" defined by a plugin which doesn't provide a validation schema for its config.
Please report the issue at its bug tracker linking: https://www.serverless.com/framework/docs/providers/aws/guide/plugins#extending-validation-schema
You may turn off this message with "configValidationMode: off" setting
```
