### PR TITLE
chore: Upgrade nodejs template packages to latest compatible

### DIFF
--- a/templates/nodejs/package.json
+++ b/templates/nodejs/package.json
@@ -6,9 +6,9 @@
 		"deploy": "npm run build && npx --no-install serverless deploy"
 	},
 	"devDependencies": {
-		"@yandex-cloud/serverless-plugin": "^1.0.2",
-		"@yandex-cloud/function-types": "^2.0.1",
-		"serverless": "^3.16.0",
-		"typescript": "^4.5.4"
+		"@yandex-cloud/serverless-plugin": "^1.7.18",
+		"@yandex-cloud/function-types": "^2.1.1",
+		"serverless": "^3.38.0",
+		"typescript": "^4.9.5"
 	}
 }


### PR DESCRIPTION
In case package manager installs exact old versions of yandex cloud serverless plugin and serverless there will be a bunch of errors from Yandex Cloud