### PR TITLE
fix: Fix info api gateway invalid domain #126

### DIFF
--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -101,7 +101,7 @@ export class YandexCloudInfo implements ServerlessPlugin {
 
         if (existingApiGateway?.id) {
             log.notice(
-                `API Gateway "${existingApiGateway.name}" deployed with url "https://${existingApiGateway.id}.apigw.yandexcloud.net/"`,
+                `API Gateway "${existingApiGateway.name}" deployed with url "https://${existingApiGateway.domain}/"`,
             );
         } else {
             log.warning(`API Gateway "${existingApiGateway.name}" not deployed`);

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -535,6 +535,7 @@ export class YandexCloudProvider implements ServerlessPlugin {
             return {
                 name: apiGateway.name,
                 id: apiGateway.id,
+                domain: apiGateway.domain,
                 domains: apiGateway.attachedDomains,
                 openapiSpec: specResponse.openapiSpec,
             };

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -325,6 +325,7 @@ export interface AttachedDomain {
 
 export interface ApiGatewayInfo {
     id?: string;
+    domain?: string;
     name: string;
     domains?: AttachedDomain[];
     openapiSpec?: string;


### PR DESCRIPTION
Test console log of `apiGateway` in provider.ts

<img width="786" alt="image" src="https://github.com/user-attachments/assets/7c1f8316-4efe-493a-93dc-8483078938db" />
